### PR TITLE
Improve stderr handling and config passing. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yeti"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "A Rust HTTP & WebSockets server for live-reloading modified SCSS files."
 
@@ -14,3 +14,4 @@ axum = { version = "0.7.5", features = ["ws"] }
 serde_json = "1.0.117"
 futures-util = "0.3.30"
 clap = "4.5.7"
+grass = "0.13.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,11 +107,12 @@ impl ServerConfig {
                         }}
 
                         const url = styleElement.getAttribute("href");
+                        const urlWithoutQuery = url.split("?")[0];
 
                         // Convert timestamp from milliseconds to seconds to mimic PHP time()
                         const timestampAsSeconds = Math.floor(new Date().getTime() / 1000);
                         // Add URL query to cache bust
-                        const url_query = url+"?ver="+timestampAsSeconds;
+                        const url_query = urlWithoutQuery+"?ver="+timestampAsSeconds;
                         // Set new URL to automatically fetch new css and bust cache
                         styleElement.setAttribute("href", url_query);
                         break;

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,10 +2,11 @@ use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
     io::{Read, Write},
+    path::Path,
     process,
 };
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct ServerConfig {
     pub watch_dir: String,
     pub input_file_path: String,
@@ -17,8 +18,21 @@ pub struct ServerConfig {
 }
 
 impl ServerConfig {
+    // Creates a new instance of the `ServerConfig` and stores parameter values within it.
+    pub fn new(config: ServerConfig) -> Self {
+        ServerConfig {
+            watch_dir: config.watch_dir,
+            input_file_path: config.input_file_path,
+            output_file_path: config.output_file_path,
+            style_tag_id: config.style_tag_id,
+            port: config.port,
+            stop_on_error: config.stop_on_error,
+            experimental: config.experimental,
+        }
+    }
+
     /// Overwrites empty JSON file with default key-value pairs.
-    pub fn set_default_json_values(file_path: &str) {
+    pub fn set_default_json_values<P: AsRef<Path>>(file_path: P) {
         println!("Updating empty yeti.json file");
         // Overwrite file with some default content
 
@@ -47,7 +61,7 @@ impl ServerConfig {
     }
 
     /// Read the JSON file and return the parsed JSON value.
-    pub fn read_json(file_path: &str) -> Self {
+    pub fn read_json<P: AsRef<Path>>(file_path: P) -> Self {
         // Unwrap safe as file existence checked prior
         let mut file = File::open(file_path).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use axum::http::header;
 use axum::routing::get;
 use axum::Router;
 use std::fs;
-use std::path::Path;
+use std::net::{IpAddr, Ipv4Addr};
 use std::process::{self, Command};
 use std::{env, net::SocketAddr};
 use tokio::net::TcpListener;
@@ -20,107 +20,103 @@ async fn main() {
     println!("🧊 Yeti v{}", env!("CARGO_PKG_VERSION"));
 
     // Check sass is installed in global path on the current system
-    match Command::new("sass").arg("--version").output() {
-        Ok(res) => {
-            let formatted_output =
-                String::from_utf8(res.stdout).expect("Failed to parse Sass output");
-            println!("   Sass installed! Version {}", formatted_output);
-        }
-        Err(e) => {
+    let sass_output = Command::new("sass")
+        .arg("--version")
+        .output()
+        .unwrap_or_else(|e| {
             eprintln!("   Sass executable not found. \nError: {:?}", e);
             process::exit(1);
-        }
-    }
+        });
 
-    // Safely exit if no yeti.json file is found
-    let config_filepath = match std::env::current_dir() {
-        Ok(path) => format!("{}/yeti.json", path.display()),
-        Err(e) => {
+    let sass_version = String::from_utf8(sass_output.stdout).unwrap();
+    println!("   Sass installed! Version {}", sass_version);
+
+    let json_path = std::env::current_dir()
+        .unwrap_or_else(|e| {
             eprintln!("🚨 Failed to get current directory. Error: {:?}", e);
             process::exit(1);
-        }
-    };
-    if !Path::new(&config_filepath).exists() {
+        })
+        .join("yeti.json");
+
+    // Safely exit if no yeti.json file is found
+    if !json_path.exists() {
         eprintln!("🚨 No yeti.json file found in the current directory. Create one to begin. Exiting... \n");
         process::exit(1);
     }
 
     // Check for existing empty json file (0 bytes in size)
-    let is_json_empty = fs::metadata(&config_filepath)
+    let is_json_empty = fs::metadata(&json_path)
         .expect("Failed to read yeti.json metadata")
         .len()
         == 0;
 
     // Set default values for empty yeti.json and exit
     if is_json_empty {
-        ServerConfig::set_default_json_values(&config_filepath);
+        ServerConfig::set_default_json_values(&json_path);
         println!("📝 Set default yeti.json key-value pairs. Update the values and re-run yeti. Exiting... \n");
         process::exit(1);
     }
 
     // Read yeti.json for configuration values
-    let ServerConfig {
-        port,
-        style_tag_id,
-        watch_dir,
-        experimental,
-        ..
-    } = ServerConfig::read_json(&config_filepath);
+    let json_config = ServerConfig::read_json(&json_path);
+    let server_config = ServerConfig::new(json_config);
 
-    if experimental {
+    if server_config.experimental {
         println!("🚧 Experimental mode enabled. Using Grass to compile Sass files.");
     }
 
     // Initialise Server Handler instance
     let server_handler = ServerHandler {};
 
-    // Create port address and parse
-    let port_addr: SocketAddr = format!("127.0.0.1:{port}")
-        .parse()
-        .expect("Failed to parse port address.");
+    // Create socket port address
+    let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_config.port);
 
     // Setup listener and app for web server router
-    let listener = match TcpListener::bind(port_addr).await {
-        Ok(listener) => listener,
-        Err(e) => {
-            eprintln!("🚨 Port:{port} is in use. Try another port. \nError: {e}",);
-            process::exit(1);
-        }
-    };
+    let listener = TcpListener::bind(socket).await.unwrap_or_else(|e| {
+        eprintln!(
+            "🚨 Port:{} is in use. Try another port. \nError: {e}",
+            server_config.port
+        );
+        process::exit(1);
+    });
 
     // Instantiate file watcher and share receiver to event channel
-    let (_watcher, watcher_rx) = WatchHandler::watcher(&watch_dir);
+    let (_watcher, watcher_rx) = WatchHandler::watcher(&server_config.watch_dir);
 
-    // Pass receiver to Web Socket route handler
-    let app = Router::new()
-        .route(
-            "/ws",
-            get(move |ws, connect_info| {
-                server_handler
-                    .clone()
-                    .ws_handler(ws, connect_info, watcher_rx)
-            }),
-        )
-        .route(
-            "/client",
-            get(move || async move {
-                (
-                    [(header::CONTENT_TYPE, "text/javascript")],
-                    ServerConfig::serve_javascript_string(port, &style_tag_id),
-                )
-            }),
-        );
     // Initialise shared file watcher & channel receiver
-    println!("🔭 Watching directory /{}... \n", watch_dir);
+    println!("🔭 Watching directory /{}... \n", &server_config.watch_dir);
     println!("✨ WebSockets Server active... \n");
     println!("🏠 Host Address: ");
-    println!("   IP: {port_addr}");
-    println!("   Socket: ws://localhost:{port}/ws \n");
+    println!("   IP: {}", socket.ip());
+    println!("   Socket: ws://localhost:{}/ws \n", socket.port());
 
-    // Start the web server
+    let yeti_state = server_config.clone();
+
+    // Pass receiver to Web Socket route handler and start the web server
     axum::serve(
         listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
+        Router::new()
+            .route(
+                "/ws",
+                get(move |ws, connect_info| {
+                    server_handler
+                        .clone()
+                        .ws_handler(ws, connect_info, watcher_rx, yeti_state)
+                }),
+            )
+            .route(
+                "/client",
+                get(move || async move {
+                    (
+                        [(header::CONTENT_TYPE, "text/javascript")],
+                        ServerConfig::serve_javascript_string(
+                            socket.port(),
+                            &server_config.style_tag_id,
+                        ),
+                    )
+                }),
+            )
+            .into_make_service_with_connect_info::<SocketAddr>(),
     )
     .await
     .expect("Could not server web server");

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,8 +63,13 @@ async fn main() {
         port,
         style_tag_id,
         watch_dir,
+        experimental,
         ..
     } = ServerConfig::read_json(&config_filepath);
+
+    if experimental {
+        println!("🚧 Experimental mode enabled. Using Grass to compile Sass files.");
+    }
 
     // Initialise Server Handler instance
     let server_handler = ServerHandler {};

--- a/src/server.rs
+++ b/src/server.rs
@@ -90,7 +90,7 @@ impl ServerHandler {
                             );
 
                             match sender.send(Message::Text("reload".to_string())).await {
-                                Ok(_) => println!("✅ Successfully sent reload message!"),
+                                Ok(_) => println!("✅ Successfully sent reload message! \n"),
                                 Err(e) => eprintln!("🚨 Failed to send reload message. {e}"),
                             }
                         } else if let Err(e) = css_result {
@@ -140,7 +140,7 @@ impl ServerHandler {
                                 );
 
                                 match sender.send(Message::Text("reload".to_string())).await {
-                                    Ok(_) => println!("✅ Successfully sent reload message!"),
+                                    Ok(_) => println!("✅ Successfully sent reload message! \n"),
                                     Err(e) => eprintln!("🚨 Failed to send reload message. {e}"),
                                 }
                             } else {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,13 +1,14 @@
-use std::io::{BufRead, BufReader};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
 use std::net::SocketAddr;
 use std::process::{Command, Stdio};
-use std::time::SystemTime;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::{extract::connect_info::ConnectInfo, response::Response};
 use futures_util::{SinkExt, StreamExt};
 use notify::event::ModifyKind;
 use notify::EventKind;
+use tokio::time::Instant;
 
 use crate::config::ServerConfig;
 use crate::watcher::SharedRx;
@@ -29,16 +30,12 @@ impl ServerHandler {
     pub async fn handle_socket(self, socket: WebSocket, who: SocketAddr, shared_rx: SharedRx) {
         println!("🤝 Incoming connection from {:?}", who);
 
-        let config_filename = format!(
-            "{}/yeti.json",
-            std::env::current_dir()
-                .expect("Couldn't get current directory")
-                .display()
-        );
+        let config_filename = format!("{}/yeti.json", std::env::current_dir().unwrap().display());
         let ServerConfig {
             input_file_path,
             output_file_path,
             stop_on_error,
+            experimental,
             ..
         } = ServerConfig::read_json(&config_filename);
 
@@ -62,73 +59,91 @@ impl ServerHandler {
         let mut watch_task = tokio::spawn(async move {
             // Channel will sleep until message in channel
             while let Some(event) = shared_rx.lock().await.recv().await {
-                match event.kind {
-                    EventKind::Modify(modify_kind) => match modify_kind {
-                        ModifyKind::Data(_) => {
-                            println!("🔨 File change. Building Sass...");
+                // Only process data modification events
+                if matches!(event.kind, EventKind::Modify(ModifyKind::Data(_))) {
+                    println!("🔨 File change. Building Sass...");
 
-                            let input_output_path = format!("{input_file_path}:{output_file_path}");
+                    let now = Instant::now();
+                    // Use Grass crate for Sass compilation
+                    if experimental {
+                        println!("🌱 Using Grass to build Sass...");
+                        let css_result = grass::from_path(
+                            &input_file_path,
+                            &grass::Options::default().style(grass::OutputStyle::Compressed),
+                        );
 
-                            // Build Args based on yeti.json configuration
-                            let mut dynamic_args: Vec<&str> = vec![
-                                if stop_on_error { "--stop-on-error" } else { "" },
-                                input_output_path.as_str(),
-                                "--style=compressed",
-                                "--no-source-map",
-                            ];
+                        if let Ok(css) = css_result {
+                            File::create(&output_file_path)
+                                .unwrap()
+                                .write_all(css.as_bytes())
+                                .expect("Failed to write CSS to output css file");
 
-                            // Discard empty args
-                            dynamic_args.retain(|&arg| !arg.is_empty());
+                            println!(
+                                "✅ Built Sass in {:.3}ms",
+                                now.elapsed().as_millis() as f64 / 1000.0
+                            );
 
-                            let now = SystemTime::now();
-                            let sass_cmd = Command::new("sass")
-                                .args(dynamic_args)
-                                .stderr(Stdio::piped())
-                                .spawn();
-
-                            let elapsed = now.elapsed().unwrap();
-
-                            match sass_cmd {
-                                Ok(mut child) => {
-                                    let stderr = child.stderr.take().unwrap();
-                                    let lines = BufReader::new(stderr).lines();
-                                    let mut count = 0;
-
-                                    // If there's an error, iterate it and increment count
-                                    lines
-                                        .inspect(|_| count += 1)
-                                        .for_each(|line| println!("{}", line.unwrap()));
-
-                                    // If there are no errors, send a reload message to the client
-                                    if count == 0 {
-                                        println!(
-                                            "✅ Built Sass in {:.3}ms",
-                                            elapsed.as_millis() as f64 / 1000.0
-                                        );
-
-                                        match sender.send(Message::Text("reload".to_string())).await
-                                        {
-                                            Ok(_) => {
-                                                println!("✅ Successfully sent reload message!");
-                                            }
-                                            Err(e) => {
-                                                eprintln!("🚨 Failed to send reload message. {e}")
-                                            }
-                                        }
-                                    } else {
-                                        eprintln!("❌ Cancelled Sass build. ");
-                                    }
-                                }
-                                Err(e) => {
-                                    eprintln!("🚨 Error building Sass: {e}");
-                                }
+                            match sender.send(Message::Text("reload".to_string())).await {
+                                Ok(_) => println!("✅ Successfully sent reload message!"),
+                                Err(e) => eprintln!("🚨 Failed to send reload message. {e}"),
                             }
+                        } else if let Err(e) = css_result {
+                            eprintln!("🚨 Error building Sass: {e}");
                         }
-                        // Ignore any other modification kind. e.g. Date, metadata, name
-                        _ => {}
-                    },
-                    // Ignore other file events. Is also filtered before by watcher
-                    _ => {}
+                    }
+                    // Default Dart Sass compilation via CLI
+                    else {
+                        let input_output_path = format!("{input_file_path}:{output_file_path}");
+
+                        // Build Args based on yeti.json configuration
+                        let mut dynamic_args: Vec<&str> = vec![
+                            if stop_on_error { "--stop-on-error" } else { "" },
+                            &input_output_path,
+                            "--style=compressed",
+                            "--no-source-map",
+                        ];
+
+                        // Discard empty args
+                        dynamic_args.retain(|&arg| !arg.is_empty());
+
+                        let sass_cmd = Command::new("sass")
+                            .args(dynamic_args)
+                            .stderr(Stdio::piped())
+                            .spawn();
+
+                        if let Ok(mut child) = sass_cmd {
+                            let stderr = child.stderr.take().unwrap();
+                            let lines = BufReader::new(stderr).lines();
+                            let mut count = 0;
+
+                            if stop_on_error {
+                                // Don't increment count in stop_on_error config option
+                                lines.for_each(|line| eprintln!("{}", line.unwrap()));
+                            } else {
+                                // If there's an error, iterate it and increment count
+                                lines
+                                    .inspect(|_| count += 1)
+                                    .for_each(|line| eprintln!("{}", line.unwrap()));
+                            }
+
+                            // If there are no errors, send a reload message to the client
+                            if count == 0 || !stop_on_error {
+                                println!(
+                                    "✅ Built Sass in {:.3}ms",
+                                    now.elapsed().as_millis() as f64 / 1000.0
+                                );
+
+                                match sender.send(Message::Text("reload".to_string())).await {
+                                    Ok(_) => println!("✅ Successfully sent reload message!"),
+                                    Err(e) => eprintln!("🚨 Failed to send reload message. {e}"),
+                                }
+                            } else {
+                                eprintln!("❌ Cancelled Sass build. ");
+                            }
+                        } else if let Err(e) = sass_cmd {
+                            eprintln!("🚨 Error building Sass: {e}");
+                        }
+                    }
                 }
             }
         });

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,22 +22,28 @@ impl ServerHandler {
         ws: WebSocketUpgrade,
         ConnectInfo(addr): ConnectInfo<SocketAddr>,
         rx: SharedRx,
+        config: ServerConfig,
     ) -> Response {
-        ws.on_upgrade(move |socket| Self::handle_socket(self, socket, addr, rx))
+        ws.on_upgrade(move |socket| Self::handle_socket(self, socket, addr, rx, config))
     }
 
     /// Handles and processes incoming socket connections and assigns them a file watcher.
-    pub async fn handle_socket(self, socket: WebSocket, who: SocketAddr, shared_rx: SharedRx) {
+    pub async fn handle_socket(
+        self,
+        socket: WebSocket,
+        who: SocketAddr,
+        shared_rx: SharedRx,
+        config: ServerConfig,
+    ) {
         println!("🤝 Incoming connection from {:?}", who);
 
-        let config_filename = format!("{}/yeti.json", std::env::current_dir().unwrap().display());
         let ServerConfig {
             input_file_path,
             output_file_path,
             stop_on_error,
             experimental,
             ..
-        } = ServerConfig::read_json(&config_filename);
+        } = config;
 
         // Split socket to monitor send/ receive in parallel
         // Also for ownership and to move within task closures

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -67,13 +67,12 @@ impl WatchHandler {
             process::exit(1);
         });
 
-        match watcher.watch(Path::new(watch_dir), RecursiveMode::Recursive) {
-            Ok(_) => {}
-            Err(e) => {
+        watcher
+            .watch(Path::new(watch_dir), RecursiveMode::Recursive)
+            .unwrap_or_else(|e| {
                 eprintln!("🚨 Failed to watch directory: {:?}", e);
                 process::exit(1);
-            }
-        }
+            });
 
         let shared_receiver = Arc::new(Mutex::new(receiver));
 

--- a/yeti.json
+++ b/yeti.json
@@ -6,5 +6,6 @@
   "output_file_path": "dist/main.css",
   "style_tag_id": "sage/css-css",
   "port": 8080,
-  "experimental": false
+  "experimental": false,
+  "stop_on_error": false
 }


### PR DESCRIPTION
Fixes issue #4 . 

- Changed repeated reads of json config file to Struct. 
- Refactored some match expressions where there was only two arms/ minimal Ok result use. 
- Reduced use of string slices in favor of other types such as PathBuffers and SocketAddresses for some operations. 
- Refactored for reduced use of string slices to improve initial checks on boot. 
- Adds experimental mode functionality for using [Grass](https://github.com/connorskees/grass) crate for faster Sass compilation
- Fixed issue with CSS query appending not removing previous query. 
- Fixed issue with tracking time elapsed. Changed from `std::time::SystemTime::now()` time to `Tokio::time::Instant::now()` time. 

The Grass crate Sass compiler does not work with the `stop_on_error` config option. 
